### PR TITLE
chore(Android): mise à jour des dépendances

### DIFF
--- a/app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/app/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip

--- a/app/android/settings.gradle
+++ b/app/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version '1.0.0'
-    id "com.android.application" version '8.7.3' apply false
+    id "com.android.application" version '8.8.0' apply false
     id "org.jetbrains.kotlin.android" version '2.0.21' apply false
     // START: FlutterFire Configuration
     id "com.google.gms.google-services" version "4.4.2" apply false

--- a/packages/dsfr.dart/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/dsfr.dart/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jun 20 17:28:09 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/dsfr.dart/example/android/settings.gradle
+++ b/packages/dsfr.dart/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version '1.0.0'
-    id "com.android.application" version '8.7.3' apply false
+    id "com.android.application" version '8.8.0' apply false
     id "org.jetbrains.kotlin.android" version '2.0.21' apply false
 }
 


### PR DESCRIPTION
- Bump Android Gradle plugin from 8.7.3 to 8.8.0 in settings.gradle files.
- Update Gradle wrapper from 8.9 to 8.10.2 in gradle-wrapper.properties files.