### PR TITLE
feat(action/car_simulator): ajout la possibilité d'aller directement aux résultats

### DIFF
--- a/app/lib/features/action/domain/action.dart
+++ b/app/lib/features/action/domain/action.dart
@@ -3,15 +3,16 @@ import 'package:app/features/know_your_customer/core/domain/question.dart';
 import 'package:equatable/equatable.dart';
 
 sealed class Action extends Equatable {
-  const Action({required this.id, required this.title, required this.subTitle, required this.why});
+  const Action({required this.id, required this.title, required this.subTitle, required this.why, required this.alreadySeen});
 
   final String id;
   final String title;
   final String? subTitle;
   final String why;
+  final bool alreadySeen;
 
   @override
-  List<Object?> get props => [id, title, subTitle, why];
+  List<Object?> get props => [id, title, subTitle, why, alreadySeen];
 }
 
 final class ActionClassic extends Action {
@@ -19,6 +20,7 @@ final class ActionClassic extends Action {
     required super.id,
     required super.title,
     required super.subTitle,
+    required super.alreadySeen,
     required super.why,
     required this.how,
     required this.services,
@@ -40,6 +42,7 @@ final class ActionSimulator extends Action {
     required super.id,
     required super.title,
     required super.subTitle,
+    required super.alreadySeen,
     required super.why,
     required this.questions,
   });

--- a/app/lib/features/action/infrastructure/action_mapper.dart
+++ b/app/lib/features/action/infrastructure/action_mapper.dart
@@ -10,6 +10,7 @@ abstract final class ActionClassicMapper {
     id: json['code'] as String,
     title: json['titre'] as String,
     subTitle: json['sous_titre'] as String?,
+    alreadySeen: json['deja_vue'] as bool,
     why: json['pourquoi'] as String,
     how: json['comment'] as String,
     services: (json['services'] as List<dynamic>).cast<Map<String, dynamic>>().map(ActionServiceMapper.fromJson).toList(),
@@ -23,6 +24,7 @@ abstract final class ActionSimulatorMapper {
     id: json['code'] as String,
     title: json['titre'] as String,
     subTitle: json['sous_titre'] as String,
+    alreadySeen: json['deja_vue'] as bool,
     why: json['pourquoi'] as String,
     questions:
         (json['kycs'] as List<dynamic>).cast<Map<String, dynamic>>().map(QuestionMapper.fromJson).whereType<Question>().toList(),

--- a/app/lib/features/action/presentation/pages/action_page.dart
+++ b/app/lib/features/action/presentation/pages/action_page.dart
@@ -9,7 +9,7 @@ import 'package:app/features/action/presentation/bloc/action_bloc.dart';
 import 'package:app/features/action/presentation/bloc/action_event.dart';
 import 'package:app/features/action/presentation/bloc/action_state.dart';
 import 'package:app/features/actions/domain/action_type.dart';
-import 'package:app/features/car_simulator/presentation/car_simulator_questions/widgets/car_simulator_widget.dart';
+import 'package:app/features/car_simulator/presentation/widgets/car_simulator_widget.dart';
 import 'package:app/features/services/lvao/presentation/widgets/lvao_horizontal_list.dart';
 import 'package:app/features/services/recipes/action/presentation/widgets/recipe_horizontal_list.dart';
 import 'package:app/l10n/l10n.dart';
@@ -174,7 +174,7 @@ class _ActionSimulatorView extends StatelessWidget {
 
   @override
   Widget build(final BuildContext context) => switch (action.getId()) {
-    ActionSimulatorId.carSimulator => const CarSimulatorWidget(),
+    ActionSimulatorId.carSimulator => CarSimulatorWidget(alreadySeen: action.alreadySeen),
   };
 }
 

--- a/app/lib/features/car_simulator/presentation/car_simulator_result/widgets/car_simulator_result.dart
+++ b/app/lib/features/car_simulator/presentation/car_simulator_result/widgets/car_simulator_result.dart
@@ -311,7 +311,7 @@ class _NumberWithUnit extends StatelessWidget {
   @override
   Widget build(final BuildContext context) => Text.rich(
     TextSpan(
-      text: FnvNumberFormat.formatNumber(num),
+      text: FnvNumberFormat.formatNumberAfterRounding(num),
       style: const DsfrTextStyle.body2XlBold(),
       children: [const TextSpan(text: ' '), TextSpan(text: unit, style: const DsfrTextStyle.bodyLg())],
     ),

--- a/app/lib/features/questions_manager/bloc/questions_manager_bloc.dart
+++ b/app/lib/features/questions_manager/bloc/questions_manager_bloc.dart
@@ -1,6 +1,7 @@
 import 'package:app/features/know_your_customer/core/domain/question.dart';
 import 'package:app/features/questions_manager/bloc/questions_manager_event.dart';
 import 'package:app/features/questions_manager/bloc/questions_manager_state.dart';
+import 'package:app/features/questions_manager/domain/cursor.dart';
 import 'package:app/features/questions_manager/domain/cursor_manager.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -10,6 +11,7 @@ class QuestionsManagerBloc extends Bloc<QuestionsManagerEvent, QuestionsManagerS
       final result = await application.first();
       emit(QuestionsManagerLoadSuccess(cursor: result));
     });
+
     on<QuestionsManagerPreviousRequested>((final event, final emit) async {
       final blocState = state;
       if (blocState is! QuestionsManagerLoadSuccess) {
@@ -18,6 +20,7 @@ class QuestionsManagerBloc extends Bloc<QuestionsManagerEvent, QuestionsManagerS
       final result = await application.previous(blocState.cursor);
       emit(QuestionsManagerLoadSuccess(cursor: result));
     });
+
     on<QuestionsManagerNextRequested>((final event, final emit) async {
       final blocState = state;
       if (blocState is! QuestionsManagerLoadSuccess) {
@@ -25,6 +28,15 @@ class QuestionsManagerBloc extends Bloc<QuestionsManagerEvent, QuestionsManagerS
       }
       final result = await application.next(blocState.cursor);
       emit(QuestionsManagerLoadSuccess(cursor: result));
+    });
+
+    on<QuestionsManagerLastQuestionRequested>((final event, final emit) async {
+      final blocState = state;
+      if (blocState is! QuestionsManagerLoadSuccess) {
+        return;
+      }
+      final result = await application.next(blocState.cursor);
+      emit(QuestionsManagerLoadSuccess(cursor: Cursor(elements: result.elements, index: result.elements.length)));
     });
   }
 }

--- a/app/lib/features/questions_manager/bloc/questions_manager_event.dart
+++ b/app/lib/features/questions_manager/bloc/questions_manager_event.dart
@@ -23,3 +23,8 @@ final class QuestionsManagerPreviousRequested extends QuestionsManagerEvent {
 final class QuestionsManagerNextRequested extends QuestionsManagerEvent {
   const QuestionsManagerNextRequested();
 }
+
+@immutable
+final class QuestionsManagerLastQuestionRequested extends QuestionsManagerEvent {
+  const QuestionsManagerLastQuestionRequested();
+}

--- a/app/lib/l10n/l10n.dart
+++ b/app/lib/l10n/l10n.dart
@@ -288,6 +288,7 @@ Si vous ne disposez pas de votre dernier avis d’impôt, renseignez la somme de
   static const questionSuivante = 'Question suivante';
   static const questionPrecedente = 'Question précédente';
   static const passerLaQuestion = 'Passer la question';
+  static const allerDirectementAuxResultats = 'Aller directement aux résultats';
 
   static String cacherEmail(final String email) {
     final indexArobase = email.characters.findFirst(Characters('@'))!.stringBeforeLength;

--- a/app/test/features/step/i_have_action_detail_in_my_library.dart
+++ b/app/test/features/step/i_have_action_detail_in_my_library.dart
@@ -15,6 +15,7 @@ Future<void> iHaveActionDetailInMyLibrary(final WidgetTester tester, final bdd.D
           'sous_titre': e['subTitle'],
           'comment': e['how'],
           'pourquoi': e['why'],
+          'deja_vue': false,
           'services': [
             {'recherche_service_id': e['service_id'], 'categorie': e['service_category']},
           ],


### PR DESCRIPTION


Lorsque l'action est déjà vue (c'est-à-dire `deja_vue = true`) alors un bouton permet d'aller directement aux résultats.

A noter, que l'on souhaiterait sûrement plutôt avoir un attribut `resultat_deja_vu`.