### PR TITLE
Filtre les simulateur inconnus

### DIFF
--- a/app/lib/features/action/domain/action.dart
+++ b/app/lib/features/action/domain/action.dart
@@ -224,6 +224,8 @@ enum ActionSimulatorId {
   const ActionSimulatorId(this.apiString);
   final String apiString;
 
+  static bool isSimulatorId(final String id) => values.any((final element) => element.apiString == id);
+
   static ActionSimulatorId fromApiString(final String id) => values.firstWhere(
     (final element) => element.apiString == id,
     orElse: () => throw UnimplementedError('Unknown simulator id: $id'),

--- a/app/lib/features/actions/infrastructure/action_catalog_mapper.dart
+++ b/app/lib/features/actions/infrastructure/action_catalog_mapper.dart
@@ -1,12 +1,19 @@
+import 'package:app/features/action/domain/action.dart';
 import 'package:app/features/actions/domain/action_catalog.dart';
 import 'package:app/features/actions/domain/action_filter.dart';
+import 'package:app/features/actions/domain/action_type.dart';
 import 'package:app/features/actions/infrastructure/action_summary_mapper.dart';
 
 abstract final class ActionCatalogMapper {
   const ActionCatalogMapper._();
 
   static ActionCatalog fromJson(final Map<String, dynamic> json) => ActionCatalog(
-    actions: (json['actions'] as List<dynamic>).cast<Map<String, dynamic>>().map(ActionSummaryMapper.fromJson).toList(),
+    actions:
+        (json['actions'] as List<dynamic>)
+            .cast<Map<String, dynamic>>()
+            .map(ActionSummaryMapper.fromJson)
+            .where((final e) => e.type != ActionType.simulator || ActionSimulatorId.isSimulatorId(e.id))
+            .toList(),
     themes:
         (json['filtres'] as List<dynamic>)
             .cast<Map<String, dynamic>>()


### PR DESCRIPTION
Le support des différentes actions simulateur risque d'être différé entre le web et le mobile et pour l'anticiper, cette PR ajoute un filtre sur les la liste des actions.